### PR TITLE
Use one WS connection for all transactions

### DIFF
--- a/src/components/bounty-setup/ApprovalReferendum.svelte
+++ b/src/components/bounty-setup/ApprovalReferendum.svelte
@@ -12,7 +12,7 @@
 	import { firstValueFrom } from 'rxjs';
 	import { activeAccount } from '../../stores';
 	import { createEventDispatcher, onMount } from 'svelte';
-	import { convertPlanckToDot, dryRunAndSubmitTransaction } from '../../utils/polkadot';
+	import { convertPlanckToDot, dryRunAndSubmitTransaction, getApi } from '../../utils/polkadot';
 	import {
 		showErrorDialog,
 		showLoadingDialog,
@@ -55,8 +55,7 @@
 		}
 		showLoadingDialog('Submitting transaction');
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			const api = await getApi();
 			const transaction = createApprovalTransaction(api);
 
 			const { errorMessage } = await dryRunAndSubmitTransaction(api, transaction, $activeAccount);
@@ -87,8 +86,7 @@
 	async function calculateFee() {
 		if (bountyInfo.id) {
 			try {
-				const wsProvider = new WsProvider('ws://localhost:8000');
-				const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+				const api = await getApi();
 				const transaction = createApprovalTransaction(api);
 
 				let observableFee = transaction.paymentInfo($activeAccount.address);
@@ -104,8 +102,7 @@
 
 	async function calculateDeposit() {
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			const api = await getApi();
 			const base = Number(
 				(api.consts.referenda.submissionDeposit.toHuman() as string).replaceAll(',', '')
 			);

--- a/src/components/bounty-setup/BountyCreation.svelte
+++ b/src/components/bounty-setup/BountyCreation.svelte
@@ -7,7 +7,8 @@
 	import {
 		dryRunAndSubmitTransaction,
 		convertDotToPlanck,
-		convertPlanckToDot
+		convertPlanckToDot,
+		getApi
 	} from '../../utils/polkadot';
 	import { isInteger } from '../../utils/common';
 	import { WALLET_CONNECT_SOURCE } from '../../utils/WcSigner';
@@ -38,8 +39,7 @@
 				showErrorDialog('wallet is not connected');
 				return;
 			}
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			let api = await getApi();
 
 			if (bountyTitle.length === 0) {
 				showErrorDialog('bounty title is empty');
@@ -113,8 +113,7 @@
 	async function calculateFee() {
 		try {
 			if (bountyValue && bountyTitle && $activeAccount) {
-				const wsProvider = new WsProvider('ws://localhost:8000');
-				const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+				let api = await getApi();
 				let value = convertDotToPlanck(BigInt(bountyValue));
 				let transaction = api.tx.bounties.proposeBounty(value, bountyTitle);
 
@@ -133,8 +132,7 @@
 	async function calculateBond() {
 		try {
 			if (bountyValue && bountyTitle && $activeAccount) {
-				const wsProvider = new WsProvider('ws://localhost:8000');
-				const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+				let api = await getApi();
 				let value = convertDotToPlanck(BigInt(bountyValue));
 				const transaction = api.tx.bounties.proposeBounty(value, bountyTitle);
 				const base = Number(

--- a/src/components/bounty-setup/BountySetup.svelte
+++ b/src/components/bounty-setup/BountySetup.svelte
@@ -16,12 +16,13 @@
 	import BountyCreation from './BountyCreation.svelte';
 	import BountySetupTab from './BountySetupTab.svelte';
 	import CuratorProposal from './CuratorProposal.svelte';
-	import { ApiPromise, WsProvider } from '@polkadot/api';
+	import { firstValueFrom } from 'rxjs';
 	import {
 		hideLoadingDialog,
 		showErrorDialog,
 		showLoadingDialog
 	} from '../../utils/loading-screen';
+	import { getApi } from '../../utils/polkadot';
 
 	let bountyInfo: BountyInfo = {};
 
@@ -66,12 +67,10 @@
 		if (bountyId) {
 			showLoadingDialog('Loading bounty info');
 			try {
-				const wsProvider = new WsProvider('ws://localhost:8000');
-				const api = await ApiPromise.create({ provider: wsProvider });
+				const api = await getApi()
 				let bountyDescription = (
-					await api.query.bounties.bountyDescriptions(bountyId)
+					await  firstValueFrom( api.query.bounties.bountyDescriptions(bountyId))
 				).toHuman() as string;
-				console.log(bountyDescription);
 				if (!bountyDescription) {
 					showErrorDialog('Failed to load bounty info');
 					return;

--- a/src/components/bounty-setup/CuratorProposal.svelte
+++ b/src/components/bounty-setup/CuratorProposal.svelte
@@ -7,6 +7,7 @@
 	import {
 		convertPlanckToDot,
 		dryRunAndSubmitTransaction,
+		getApi,
 		isValidAddress
 	} from '../../utils/polkadot';
 	import { isInteger } from '../../utils/common';
@@ -48,8 +49,7 @@
 		}
 
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			const api = await getApi();
 			if (!curatorFee) {
 				showErrorDialog('Invalid value of curator fee');
 				return;
@@ -91,8 +91,7 @@
 
 	async function calculateDeposit() {
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			const api = await getApi();
 			const base = Number(
 				(api.consts.referenda.submissionDeposit.toHuman() as string).replaceAll(',', '')
 			);
@@ -106,8 +105,7 @@
 	async function calculateFee() {
 		try {
 			if (curatorAddress && curatorFee && $activeAccount) {
-				const wsProvider = new WsProvider('ws://localhost:8000');
-				const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+				const api = await getApi();
 				const transaction = createProposalTransaction(api);
 				let observableFee = transaction.paymentInfo($activeAccount.address);
 				fee =

--- a/src/components/curator-actions/AcceptCuratorRole.svelte
+++ b/src/components/curator-actions/AcceptCuratorRole.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Bounty } from '../../types/bounty';
-	import { convertPlanckToDot, dryRunAndSubmitTransaction } from '../../utils/polkadot';
+	import { convertPlanckToDot, dryRunAndSubmitTransaction, getApi } from '../../utils/polkadot';
 	import BountyDialog from '../BountyDialog.svelte';
 	import { ApiRx, WsProvider } from '@polkadot/api';
 	import { firstValueFrom } from 'rxjs';
@@ -33,8 +33,7 @@
 				showErrorDialog('wallet is not connected');
 				return;
 			}
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			let api = await getApi();
 
 			let transaction = api.tx.bounties.acceptCurator(bounty.id);
 			const { errorMessage, result } = await dryRunAndSubmitTransaction(
@@ -71,8 +70,7 @@
 
 	async function calculateFee() {
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			let api = await getApi();
 			let transaction = api.tx.bounties.acceptCurator(bounty.id);
 
 			let observableFee = transaction.paymentInfo($activeAccount.address);

--- a/src/components/curator-actions/AddChildBounty.svelte
+++ b/src/components/curator-actions/AddChildBounty.svelte
@@ -3,7 +3,8 @@
 	import {
 		convertDotToPlanck,
 		convertPlanckToDot,
-		dryRunAndSubmitTransaction
+		dryRunAndSubmitTransaction,
+		getApi
 	} from '../../utils/polkadot';
 	import BountyDialog from '../BountyDialog.svelte';
 	import { ApiRx, WsProvider } from '@polkadot/api';
@@ -40,9 +41,8 @@
 				showErrorDialog('wallet is not connected');
 				return;
 			}
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
 
+			const api = await getApi();
 			if (bountyTitle.length === 0) {
 				showErrorDialog('bounty title is empty');
 				return;
@@ -95,8 +95,7 @@
 	async function calculateFee() {
 		try {
 			if (bountyValue && bountyTitle && $activeAccount) {
-				const wsProvider = new WsProvider('ws://localhost:8000');
-				const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+				let api = await getApi();
 				let value = convertDotToPlanck(BigInt(bountyValue));
 				let transaction = api.tx.childBounties.addChildBounty(bounty.id, value, bountyTitle);
 

--- a/src/components/curator-actions/AwardBounty.svelte
+++ b/src/components/curator-actions/AwardBounty.svelte
@@ -3,6 +3,7 @@
 	import {
 		convertPlanckToDot,
 		dryRunAndSubmitTransaction,
+		getApi,
 		isValidAddress
 	} from '../../utils/polkadot';
 	import BountyDialog from '../BountyDialog.svelte';
@@ -41,8 +42,7 @@
 				return;
 			}
 
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			let api = await getApi();
 
 			let transaction = api.tx.bounties.awardBounty(bounty.id, beneficiary);
 
@@ -79,8 +79,7 @@
 
 	async function calculateFee() {
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			let api = await getApi();
 
 			let transaction = api.tx.bounties.awardBounty(bounty.id, $activeAccount.address);
 			let observableFee = transaction.paymentInfo($activeAccount.address);

--- a/src/components/curator-actions/CuratorActions.svelte
+++ b/src/components/curator-actions/CuratorActions.svelte
@@ -6,12 +6,14 @@
 	import { bounties } from '../../stores';
 	import type { ChildBounty } from '../../types/child-bounty';
 	import { parseBounty, parseChildBounty } from '../../utils/common';
+	import { firstValueFrom } from 'rxjs';
 	import {
 		hideLoadingDialog,
 		showErrorDialog,
 		showLoadingDialog
 	} from '../../utils/loading-screen';
 	import { goto } from '$app/navigation';
+	import { getApi } from '../../utils/polkadot';
 
 	onMount(async () => {
 		if ($bounties.length !== 0) {
@@ -19,12 +21,11 @@
 		}
 		showLoadingDialog('Loading...');
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await ApiPromise.create({ provider: wsProvider });
+			const api = await getApi();
 			const parsedBounties: Bounty[] = [];
 
 			// Query all bounties.
-			const unparsedBounties = await api.query.bounties.bounties.entries();
+			const unparsedBounties = await firstValueFrom(api.query.bounties.bounties.entries());
 			for (let unparsedBounty of unparsedBounties) {
 				let index = Number((unparsedBounty[0].toHuman() as unknown as any)[0].replace(',', ''));
 				parsedBounties.push(parseBounty(unparsedBounty[1].toHuman(), index));
@@ -39,7 +40,9 @@
 			});
 
 			// Query bounty description.
-			const bountiesDescriptions = await api.query.bounties.bountyDescriptions.entries();
+			const bountiesDescriptions = await firstValueFrom(
+				api.query.bounties.bountyDescriptions.entries()
+			);
 			for (let desc of bountiesDescriptions) {
 				let index = Number((desc[0].toHuman() as unknown as any)[0].replace(',', ''));
 				let description = desc[1].toHuman() as string;
@@ -51,7 +54,9 @@
 
 			// Query child bounties.
 			let childBounties: ChildBounty[] = [];
-			const unparsedChildBounties = await api.query.childBounties.childBounties.entries();
+			const unparsedChildBounties = await firstValueFrom(
+				api.query.childBounties.childBounties.entries()
+			);
 			for (let childBounty of unparsedChildBounties) {
 				let id = Number((childBounty[0].toHuman() as unknown as any)[1].replace(',', ''));
 				childBounties.push(parseChildBounty(childBounty[1].toHuman(), id));
@@ -64,8 +69,9 @@
 			}
 
 			// Query child bounty description.
-			const childBountiesDescriptions =
-				await api.query.childBounties.childBountyDescriptions.entries();
+			const childBountiesDescriptions = await firstValueFrom(
+				api.query.childBounties.childBountyDescriptions.entries()
+			);
 			for (let desc of childBountiesDescriptions) {
 				let index = Number((desc[0].toHuman() as unknown as any)[0].replace(',', ''));
 				let description = desc[1].toHuman() as string;

--- a/src/components/curator-actions/child-bounties/AcceptSubCuratorRole.svelte
+++ b/src/components/curator-actions/child-bounties/AcceptSubCuratorRole.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { convertPlanckToDot, dryRunAndSubmitTransaction } from '../../../utils/polkadot';
+	import { convertPlanckToDot, dryRunAndSubmitTransaction, getApi } from '../../../utils/polkadot';
 	import BountyDialog from '../../BountyDialog.svelte';
 	import { ApiRx, WsProvider } from '@polkadot/api';
 	import { firstValueFrom } from 'rxjs';
@@ -32,8 +32,7 @@
 				showErrorDialog('Wallet is not connected');
 				return;
 			}
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			const api = await getApi();
 
 			let transaction = api.tx.childBounties.acceptCurator(
 				childBounty.parentBounty,
@@ -73,8 +72,7 @@
 
 	async function calculateFee() {
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			const api = await getApi()
 			let transaction = api.tx.childBounties.acceptCurator(
 				childBounty.parentBounty,
 				childBounty.id

--- a/src/components/curator-actions/child-bounties/AssignSubCurator.svelte
+++ b/src/components/curator-actions/child-bounties/AssignSubCurator.svelte
@@ -2,6 +2,7 @@
 	import {
 		convertPlanckToDot,
 		dryRunAndSubmitTransaction,
+		getApi,
 		isValidAddress
 	} from '../../../utils/polkadot';
 	import BountyDialog from '../../BountyDialog.svelte';
@@ -25,16 +26,6 @@
 	let curatorAddress = '';
 	let curatorFee = '';
 	let fee = '-';
-
-	const WS_URL = 'ws://localhost:8000';
-	let api: ApiRx;
-
-	async function getApi(): Promise<ApiRx> {
-		if (api) return api;
-		const wsProvider = new WsProvider(WS_URL);
-		api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
-		return api;
-	}
 
 	onMount(async () => {
 		await calculateFee();

--- a/src/components/curator-actions/child-bounties/AwardChildBounty.svelte
+++ b/src/components/curator-actions/child-bounties/AwardChildBounty.svelte
@@ -2,6 +2,7 @@
 	import {
 		convertPlanckToDot,
 		dryRunAndSubmitTransaction,
+		getApi,
 		isValidAddress
 	} from '../../../utils/polkadot';
 	import BountyDialog from '../../BountyDialog.svelte';
@@ -20,21 +21,12 @@
 	export let open = true;
 	export let childBounty: ChildBounty;
 
-	const WS_URL = 'ws://localhost:8000';
-	let api: ApiRx;
 	let beneficiary = '';
 	let fee = '-';
 
 	onMount(async () => {
 		await calculateFee();
 	});
-
-	async function getApi(): Promise<ApiRx> {
-		if (api) return api;
-		const wsProvider = new WsProvider(WS_URL);
-		api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
-		return api;
-	}
 
 	async function submit() {
 		open = false;

--- a/src/components/curator-actions/child-bounties/CloseDownChildBounty.svelte
+++ b/src/components/curator-actions/child-bounties/CloseDownChildBounty.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { convertPlanckToDot, dryRunAndSubmitTransaction } from '../../../utils/polkadot';
+	import { convertPlanckToDot, dryRunAndSubmitTransaction, getApi } from '../../../utils/polkadot';
 	import BountyDialog from '../../BountyDialog.svelte';
 	import { ApiRx, WsProvider } from '@polkadot/api';
 	import { firstValueFrom } from 'rxjs';
@@ -33,9 +33,7 @@
 				return;
 			}
 
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
-
+			const api = await getApi();
 			let transaction = api.tx.childBounties.closeChildBounty(
 				childBounty.parentBounty,
 				childBounty.id
@@ -74,8 +72,7 @@
 
 	async function calculateFee() {
 		try {
-			const wsProvider = new WsProvider('ws://localhost:8000');
-			const api = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+			const api = await getApi()
 			let transaction = api.tx.childBounties.closeChildBounty(
 				childBounty.parentBounty,
 				childBounty.id
@@ -101,11 +98,10 @@
 			{/if}
 		</div>
 		<div class="m-y-4">
-		  <p>Only close a child bounty after communicating with the sub-curator and the projected beneficiary.
-
-The funds will be reallocated to the parent bounty. </p>
-
-
+			<p>
+				Only close a child bounty after communicating with the sub-curator and the projected
+				beneficiary. The funds will be reallocated to the parent bounty.
+			</p>
 		</div>
 
 		<div>

--- a/src/routes/chopsticks/+page.svelte
+++ b/src/routes/chopsticks/+page.svelte
@@ -1,20 +1,24 @@
 <script lang="ts">
 	import '../../app.css';
-	import { ApiPromise, WsProvider } from '@polkadot/api';
+	import { api, nodeEndpoint } from '../../stores';
+	import { goto } from '$app/navigation';
+	import { getApi } from '../../utils/polkadot';
+	import { firstValueFrom } from 'rxjs';
 
 	let days: number = 1;
 	let hours = 1;
 	let mins = 1;
 	let blocks = 1;
 
+	let nodeEndpointInput = '';
+
 	async function fastForward(blocks: number) {
-		const wsProvider = new WsProvider('ws://localhost:8000');
-		const api = await ApiPromise.create({ provider: wsProvider });
-		let number = (await api.rpc.chain.getHeader()).number.toNumber();
-		await api.rpc('dev_newBlock', {
+		const api = await getApi();
+		let number = (await firstValueFrom(api.rpc.chain.getHeader())).number.toNumber();
+		await firstValueFrom( api.rpc('dev_newBlock', {
 			count: 1,
 			unsafeBlockHeight: number + blocks
-		});
+		}));
 	}
 
 	async function fastForwardDays() {
@@ -31,6 +35,11 @@
 
 	async function fastForwardBlocks() {
 		fastForward(blocks);
+	}
+
+	async function changeEndpoint() {
+		nodeEndpoint.set(nodeEndpointInput);
+		api.set(undefined);
 	}
 </script>
 
@@ -56,6 +65,17 @@
 		<button on:click={fastForwardBlocks} class="button-active min-w-40">BLOCKS </button>
 		<p>(*6 seconds)</p>
 	</div>
+
+	<hr class="border-gray mt-5 mb-1 w-1/2" />
+
+	<div class="m-5 gap-5">
+		<p class="text-sm">Current node endpoint: {$nodeEndpoint}</p>
+		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white" bind:value={nodeEndpointInput} />
+		<button on:click={changeEndpoint} class="mx-5 button-active min-w-40">Change </button>
+	</div>
+	<button class="button-active mx-5" on:click={() => goto('/curator-actions')}>
+		=> Curator Actions</button
+	>
 </div>
 
 <style lang="postcss">

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -5,6 +5,11 @@ import type { SessionTypes } from '@walletconnect/types';
 import { WalletConnectSigner } from './utils/WcSigner';
 import type { LoadingDialogState } from './types/loading-screen';
 import type { Bounty } from './types/bounty';
+import type { ApiRx } from '@polkadot/api';
+
+export const nodeEndpoint = writable('ws://localhost:8000');
+
+export const api = writable();
 
 // Session.
 export const isLoggedIn = writable(false);
@@ -37,5 +42,5 @@ const state: LoadingDialogState = {
 };
 export const loadingDialogState = writable(state);
 
-const BountiesArray: Bounty[] = []
-export const bounties = writable(BountiesArray)
+const BountiesArray: Bounty[] = [];
+export const bounties = writable(BountiesArray);

--- a/src/utils/polkadot.ts
+++ b/src/utils/polkadot.ts
@@ -1,4 +1,4 @@
-import { ApiRx } from '@polkadot/api';
+import { ApiRx, WsProvider } from '@polkadot/api';
 import type { SubmittableExtrinsic } from '@polkadot/api/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 import { firstValueFrom, filter } from 'rxjs';
@@ -7,7 +7,7 @@ import type { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
 import { web3FromAddress } from '@polkadot/extension-dapp';
 import { WALLET_CONNECT_SOURCE, WalletConnectSigner } from './WcSigner';
 import { get } from 'svelte/store';
-import { walletConnectProvider, walletConnectSession } from '../stores';
+import { api, nodeEndpoint, walletConnectProvider, walletConnectSession } from '../stores';
 
 export function convertDotToPlanck(value: bigint) {
 	return value * 10000000000n;
@@ -19,6 +19,18 @@ export function convertPlanckToDot(value: number | bigint): number {
 		return Number(value / BigInt(10000000000));
 	}
 	return value / 10000000000;
+}
+
+export async function getApi(): Promise<ApiRx> {
+	const apiFromStore = get(api) as unknown as ApiRx | undefined;
+
+	if (apiFromStore) {
+		return apiFromStore;
+	}
+	const wsProvider = new WsProvider(get(nodeEndpoint));
+	const apiNew = await firstValueFrom(ApiRx.create({ provider: wsProvider }));
+	api.set(apiNew);
+	return apiNew;
 }
 
 /**
@@ -99,7 +111,10 @@ export async function dryRunAndSubmitTransaction(
 			return { result: submittableResult, errorMessage: errorMsg };
 		} else {
 			console.error(submittableResult.toHuman());
-			return { result: submittableResult, errorMessage: `Something went wrong, ${submittableResult.dispatchError || ""}` };
+			return {
+				result: submittableResult,
+				errorMessage: `Something went wrong, ${submittableResult.dispatchError || ''}`
+			};
 		}
 	}
 	return { result: submittableResult };


### PR DESCRIPTION
Use the store for api to avoid creating an api on each query/transaction. 
Also adds the option to change the api endpoint in the `/chopsticks` page.