### PR TITLE
Persist wallet connection on page refresh

### DIFF
--- a/src/components/app-bar/AppBar.svelte
+++ b/src/components/app-bar/AppBar.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
 	import {
-		isLoggedIn,
-		loggedAccounts,
 		activeAccount,
 		activeAccountBounties,
 		showAllBounties,
@@ -14,6 +13,7 @@
 	import LogoBountyManagerMobile from '../svg/header-footer-logos/LogoBountyManagerMobile.svelte';
 	import LogoutIcon from '../svg/header-footer-logos/LogoutIcon.svelte';
 	import LoginDialog from './LoginDialog.svelte';
+	import { SetActiveAccountBounties } from '../../utils/bounties';
 
 	let loginDialogOpen = false;
 
@@ -21,11 +21,18 @@
 		loginDialogOpen = true;
 	}
 
+	onMount(() => {
+		// Connect wallet automatically on the same tab.
+		let account = sessionStorage.getItem('account');
+
+		if (account) {
+			activeAccount.set(JSON.parse(account));
+			SetActiveAccountBounties();
+		}
+	});
+
 	async function logOut() {
-		loggedAccounts.set([]);
-		// ToDo: reset active account as well
-		// activeAccount;
-		isLoggedIn.set(false);
+		activeAccount.set(undefined);
 		activeAccountBounties.set([]);
 	}
 </script>

--- a/src/components/app-bar/LoginDialog.svelte
+++ b/src/components/app-bar/LoginDialog.svelte
@@ -21,7 +21,7 @@
 	import { web3Accounts, web3Enable, web3FromSource } from '@polkadot/extension-dapp';
 	import { walletConnect } from './wallet-connect';
 	import type { InjectedAccountWithMeta } from '@polkadot/extension-inject/types';
-	import { isLoggedIn, loggedAccounts, activeAccount } from '../../stores';
+	import { activeAccount } from '../../stores';
 	import { SetActiveAccountBounties } from '../../utils/bounties';
 
 	const POLKADOT_EXTENSION = 'polkadot-js';
@@ -130,16 +130,14 @@
 					accounts[i].meta.name = `[${extensionName}] ${i + 1}`;
 				}
 			}
-
-			loggedAccounts.set(accounts);
 		}
 
 		currentPhase = 'accountSelection';
 	}
 
 	function selectAccount(account: InjectedAccountWithMeta) {
-		isLoggedIn.set(true);
 		activeAccount.set(account);
+		sessionStorage.setItem('account', JSON.stringify(account));
 		SetActiveAccountBounties();
 		open = false;
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,5 +4,8 @@
 
 	onMount(() => {
 		goto('/curator-actions');
+		let a = sessionStorage.getItem("account")
+		console.log(a)
+		console.log(">>>>>>>>>>>>>>>")
 	});
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,8 +4,5 @@
 
 	onMount(() => {
 		goto('/curator-actions');
-		let a = sessionStorage.getItem("account")
-		console.log(a)
-		console.log(">>>>>>>>>>>>>>>")
 	});
 </script>

--- a/src/routes/chopsticks/+page.svelte
+++ b/src/routes/chopsticks/+page.svelte
@@ -72,7 +72,10 @@
 
 	<div class="m-5 gap-5">
 		<p class="text-sm">Current node endpoint: {$nodeEndpoint}</p>
-		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white min-w-40" bind:value={nodeEndpointInput} />
+		<input
+			class="border pt-1 pl-2 w-1/4 rounded-md bg-white min-w-40"
+			bind:value={nodeEndpointInput}
+		/>
 		<button on:click={changeEndpoint} class="mx-5 button-active min-w-40">Change </button>
 	</div>
 	<button class="button-active mx-5" on:click={() => goto('/curator-actions')}>

--- a/src/routes/chopsticks/+page.svelte
+++ b/src/routes/chopsticks/+page.svelte
@@ -45,25 +45,25 @@
 	}
 </script>
 
-<div class="p-40">
+<div class="py-40 md:px-40">
 	<h1 class="m-5 text-2xl font-bold">Fast Forward</h1>
 	<div class="flex m-5 gap-3">
-		<input bind:value={days} class="border pt-1 pl-2 w-1/4 rounded-md bg-white" />
+		<input bind:value={days} class="border pt-1 pl-2 w-1/4 rounded-md bg-white min-w-40" />
 		<button on:click={fastForwardDays} class="button-active min-w-40">DAYS</button>
 	</div>
 
 	<div class="flex m-5 gap-3">
-		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white" bind:value={hours} />
+		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white min-w-40" bind:value={hours} />
 		<button on:click={fastForwardHours} class="button-active min-w-40">HOURS</button>
 	</div>
 
 	<div class="flex m-5 gap-3">
-		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white" bind:value={mins} />
+		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white min-w-40" bind:value={mins} />
 		<button on:click={fastForwardMinutes} class="button-active min-w-40">MINUTES</button>
 	</div>
 
 	<div class="flex m-5 gap-3 items-center">
-		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white" bind:value={blocks} />
+		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white min-w-40" bind:value={blocks} />
 		<button on:click={fastForwardBlocks} class="button-active min-w-40">BLOCKS </button>
 		<p>(*6 seconds)</p>
 	</div>
@@ -72,7 +72,7 @@
 
 	<div class="m-5 gap-5">
 		<p class="text-sm">Current node endpoint: {$nodeEndpoint}</p>
-		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white" bind:value={nodeEndpointInput} />
+		<input class="border pt-1 pl-2 w-1/4 rounded-md bg-white min-w-40" bind:value={nodeEndpointInput} />
 		<button on:click={changeEndpoint} class="mx-5 button-active min-w-40">Change </button>
 	</div>
 	<button class="button-active mx-5" on:click={() => goto('/curator-actions')}>

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -12,10 +12,6 @@ export const nodeEndpoint = writable('ws://localhost:8000');
 export const api = writable();
 
 // Session.
-export const isLoggedIn = writable(false);
-
-export const loggedAccounts = writable<InjectedAccountWithMeta[]>([]);
-
 export const activeAccount = writable<InjectedAccountWithMeta | undefined>(undefined);
 
 export const usedExtension = writable<string>('');


### PR DESCRIPTION
Use session storage to keep user signed in after page refresh. Stored data will be deleted if the tab or the browser was closed. 

Also
- chopsticks page was a bit improved to work on mobile.
- some unnecessary svelte storage items were removed. 