### PR TITLE
Fix WalletConnect Disconnection

### DIFF
--- a/src/components/app-bar/AppBar.svelte
+++ b/src/components/app-bar/AppBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import {  onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import {
 		walletConnect as wcConnection,
 		activeAccount,

--- a/src/components/app-bar/AppBar.svelte
+++ b/src/components/app-bar/AppBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
-	import { onDestroy, onMount } from 'svelte';
+	import {  onMount } from 'svelte';
 	import {
 		walletConnect as wcConnection,
 		activeAccount,

--- a/src/components/app-bar/AppBar.svelte
+++ b/src/components/app-bar/AppBar.svelte
@@ -31,12 +31,6 @@
 		loginDialogOpen = true;
 	}
 
-	onDestroy(async () => {
-		if ($wcConnection) {
-			await $wcConnection.disconnect();
-		}
-	});
-
 	onMount(async () => {
 		// Connect wallet automatically on the same tab.
 		let account = sessionStorage.getItem('account');


### PR DESCRIPTION
This is a leftover code when we wanted to have a new WalletConnect session on each page load. Disconnecting to wallet connect `onDestroy` didn't work anyways. Now WalletConnect keeps its own session stored and it gets restored when the page loads.