### PR TITLE
Change wallet items colors

### DIFF
--- a/src/components/app-bar/AccountItem.svelte
+++ b/src/components/app-bar/AccountItem.svelte
@@ -34,19 +34,14 @@
 	.identicon {
 		width: 40px;
 		height: 40px;
+		flex-shrink: 0;
 	}
 
 	.details {
 		display: flex;
 		flex-direction: column;
 		align-items: start;
-		max-width: 350px;
-	}
-
-	@media (max-width: 768px) {
-		.details {
-			max-width: 250px;
-		}
+		max-width: calc(100% - 48px);
 	}
 
 	.address {
@@ -55,5 +50,6 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: 100%;
+		flex-shrink: 1;
 	}
 </style>

--- a/src/components/app-bar/AccountItem.svelte
+++ b/src/components/app-bar/AccountItem.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { truncateString } from '../../utils/common';
 	import PolkadotIcon from '../common/PolkadotIcon.svelte';
 	import PeopleChainName from '../PeopleChainName.svelte';
 
@@ -8,20 +7,20 @@
 </script>
 
 <!-- Account Identicon and Name -->
-<div class="accountInfo">
+<div class="info">
 	<div class="identicon">
 		<PolkadotIcon {address} />
 	</div>
-	<div class="accountDetails">
+	<div class="details">
 		<span>{name}</span>
-		<span class="accountAddress">
-			<PeopleChainName {address}>{truncateString(address, 20)}</PeopleChainName>
+		<span class="address">
+			<PeopleChainName {address}>{address}</PeopleChainName>
 		</span>
 	</div>
 </div>
 
 <style>
-	.accountInfo {
+	.info {
 		display: flex;
 		align-items: center;
 		cursor: pointer;
@@ -37,12 +36,24 @@
 		height: 40px;
 	}
 
-	.accountDetails {
+	.details {
 		display: flex;
 		flex-direction: column;
 		align-items: start;
+		max-width: 350px;
 	}
-	.accountAddress {
+
+	@media (max-width: 768px) {
+		.details {
+			max-width: 250px;
+		}
+	}
+
+	.address {
 		font-size: 14px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100%;
 	}
 </style>

--- a/src/components/app-bar/AccountItem.svelte
+++ b/src/components/app-bar/AccountItem.svelte
@@ -6,16 +6,14 @@
 	export let address: string;
 </script>
 
-<!-- Account Identicon and Name -->
 <div class="info">
 	<div class="identicon">
 		<PolkadotIcon {address} />
 	</div>
 	<div class="details">
-		<span>{name}</span>
-		<span class="address">
-			<PeopleChainName {address}>{address}</PeopleChainName>
-		</span>
+		{name}
+		<br />
+		<PeopleChainName {address}>{address}</PeopleChainName>
 	</div>
 </div>
 
@@ -38,18 +36,10 @@
 	}
 
 	.details {
-		display: flex;
-		flex-direction: column;
-		align-items: start;
-		max-width: calc(100% - 48px);
-	}
-
-	.address {
-		font-size: 14px;
-		white-space: nowrap;
+		flex-grow: 1;
 		overflow: hidden;
+		white-space: nowrap;
 		text-overflow: ellipsis;
-		max-width: 100%;
-		flex-shrink: 1;
+		text-align: left;
 	}
 </style>

--- a/src/components/app-bar/AccountItem.svelte
+++ b/src/components/app-bar/AccountItem.svelte
@@ -1,32 +1,48 @@
 <script lang="ts">
 	import { truncateString } from '../../utils/common';
 	import PolkadotIcon from '../common/PolkadotIcon.svelte';
-	import ForwardIcon from '../svg/ForwardIcon.svg';
 	import PeopleChainName from '../PeopleChainName.svelte';
 
 	export let name;
 	export let address: string;
 </script>
 
-<div
-	class="cursor-pointer flex justify-between items-center bg-backgroundButtonDark bg-opacity-20 px-2 s:px-5 py-2 rounded-lg mt-2"
->
-	<!-- Account Identicon and Name -->
-	<div class="flex items-center space-x-3">
-		<div class="w-10 h-10">
-			<PolkadotIcon {address} />
-		</div>
-		<div class="flex flex-col">
-			<span class="self-start">{name}</span>
-			<span class="text-sm whitespace-nowrap">
-				<PeopleChainName {address}>{truncateString(address, 20)}</PeopleChainName>
-			</span>
-		</div>
+<!-- Account Identicon and Name -->
+<div class="accountInfo">
+	<div class="identicon">
+		<PolkadotIcon {address} />
 	</div>
-
-	<!-- Action Button -->
-	<div class="flex items-center space-x-1">
-		<span class="text-base">Select</span>
-		<span class="mb-1"><img src={ForwardIcon} alt="Forward" /></span>
+	<div class="accountDetails">
+		<span>{name}</span>
+		<span class="accountAddress">
+			<PeopleChainName {address}>{truncateString(address, 20)}</PeopleChainName>
+		</span>
 	</div>
 </div>
+
+<style>
+	.accountInfo {
+		display: flex;
+		align-items: center;
+		cursor: pointer;
+		background-color: theme('colors.backgroundButtonLight');
+		gap: 12px;
+		padding: 8px;
+		border-radius: 8px;
+		margin-top: 8px;
+	}
+
+	.identicon {
+		width: 40px;
+		height: 40px;
+	}
+
+	.accountDetails {
+		display: flex;
+		flex-direction: column;
+		align-items: start;
+	}
+	.accountAddress {
+		font-size: 14px;
+	}
+</style>

--- a/src/components/app-bar/WalletItem.svelte
+++ b/src/components/app-bar/WalletItem.svelte
@@ -40,12 +40,12 @@
 	}
 
 	.walletAvailable {
-		background-color: theme('colors.backgroundButtonDark');
-		color: theme('colors.backgroundApp');
+		background-color: theme('colors.backgroundButtonLight');
 	}
 
 	.walletUnavailable {
-		background-color: theme('colors.backgroundButtonLight');
+		background-color: theme('colors.backgroundButtonDark');
+		color: theme('colors.backgroundApp');
 	}
 
 	@media (min-width: 375px) {

--- a/src/components/app-bar/WalletItem.svelte
+++ b/src/components/app-bar/WalletItem.svelte
@@ -2,22 +2,23 @@
 	import type { WalletInfo } from './walletInfo';
 
 	export let wallet: WalletInfo;
-	const opacity = wallet.available ? 'bg-opacity-30' : 'bg-opacity-20';
 </script>
 
 <span
-	class="cursor-pointer flex flex-col p-2 s:flex-row s:justify-between s:items-center s:p-4 rounded-lg bg-backgroundButtonDark {opacity}"
+	class="walletContainer"
+	class:walletAvailable={wallet.available}
+	class:walletUnavailable={!wallet.available}
 >
 	<!-- Wallet Icon and Name -->
-	<span class="flex items-center space-x-1 sm:space-x-2">
-		<span class="w-10 h-10">
+	<span class="walletInfo">
+		<span class="walletIcon">
 			<img src={wallet.icon} alt="Logo" />
 		</span>
-		<span class="text-2xl">{wallet.name}</span>
+		<span class="walletName">{wallet.name}</span>
 	</span>
 
 	<!-- Action Button -->
-	<span class="flex justify-end items-center sm:space-x-2">
+	<span class="walletAction">
 		<span>
 			{#if wallet.available}
 				Connect
@@ -25,6 +26,67 @@
 				Download
 			{/if}
 		</span>
-		<span class="material-symbols-outlined mb-1"> arrow_forward_ios </span>
+		<span class="material-symbols-outlined walletIconArrow"> arrow_forward_ios </span>
 	</span>
 </span>
+
+<style>
+	.walletContainer {
+		cursor: pointer;
+		display: flex;
+		flex-direction: column;
+		padding: 8px;
+		border-radius: 8px;
+	}
+
+	.walletAvailable {
+		background-color: theme('colors.backgroundButtonDark');
+		color: theme('colors.backgroundApp');
+	}
+
+	.walletUnavailable {
+		background-color: theme('colors.backgroundButtonLight');
+	}
+
+	@media (min-width: 375px) {
+		.walletContainer {
+			flex-direction: row;
+			justify-content: space-between;
+			align-items: center;
+			padding: 16px;
+		}
+	}
+
+	.walletInfo {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+	}
+
+	@media (min-width: 375px) {
+		.walletInfo {
+			gap: 8px;
+		}
+	}
+
+	.walletIcon {
+		width: 40px;
+		height: 40px;
+	}
+
+	.walletName {
+		font-size: 1.5rem;
+	}
+
+	.walletAction {
+		display: flex;
+		justify-content: end;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.walletIconArrow {
+		margin-bottom: 4px;
+		font-size: 16px;
+	}
+</style>

--- a/src/components/app-bar/WalletItem.svelte
+++ b/src/components/app-bar/WalletItem.svelte
@@ -4,21 +4,17 @@
 	export let wallet: WalletInfo;
 </script>
 
-<span
-	class="walletContainer"
-	class:walletAvailable={wallet.available}
-	class:walletUnavailable={!wallet.available}
->
+<span class="container" class:available={wallet.available} class:unavailable={!wallet.available}>
 	<!-- Wallet Icon and Name -->
-	<span class="walletInfo">
-		<span class="walletIcon">
+	<span class="info">
+		<span class="icon">
 			<img src={wallet.icon} alt="Logo" />
 		</span>
-		<span class="walletName">{wallet.name}</span>
+		<span class="name">{wallet.name}</span>
 	</span>
 
 	<!-- Action Button -->
-	<span class="walletAction">
+	<span class="action">
 		<span>
 			{#if wallet.available}
 				Connect
@@ -26,12 +22,12 @@
 				Download
 			{/if}
 		</span>
-		<span class="material-symbols-outlined walletIconArrow"> arrow_forward_ios </span>
+		<span class="material-symbols-outlined arrow"> arrow_forward_ios </span>
 	</span>
 </span>
 
 <style>
-	.walletContainer {
+	.container {
 		cursor: pointer;
 		display: flex;
 		flex-direction: column;
@@ -39,17 +35,17 @@
 		border-radius: 8px;
 	}
 
-	.walletAvailable {
+	.available {
 		background-color: theme('colors.backgroundButtonLight');
 	}
 
-	.walletUnavailable {
+	.unavailable {
 		background-color: theme('colors.backgroundButtonDark');
 		color: theme('colors.backgroundApp');
 	}
 
 	@media (min-width: 375px) {
-		.walletContainer {
+		.container {
 			flex-direction: row;
 			justify-content: space-between;
 			align-items: center;
@@ -57,35 +53,34 @@
 		}
 	}
 
-	.walletInfo {
+	.info {
 		display: flex;
 		align-items: center;
 		gap: 4px;
 	}
 
 	@media (min-width: 375px) {
-		.walletInfo {
+		.info {
 			gap: 8px;
 		}
 	}
 
-	.walletIcon {
+	.icon {
 		width: 40px;
 		height: 40px;
 	}
 
-	.walletName {
+	.name {
 		font-size: 1.5rem;
 	}
 
-	.walletAction {
+	.action {
 		display: flex;
-		justify-content: end;
 		align-items: center;
 		gap: 8px;
 	}
 
-	.walletIconArrow {
+	.arrow {
 		margin-bottom: 4px;
 		font-size: 16px;
 	}


### PR DESCRIPTION
The wallets which are available should have a more distinctive color than the ones which are not available and need to be downloaded. 

The decision was made to reuse the already available button colors, i.e the darker color for unavailable wallets and the lighter one for the available ones. 

Furthermore the "select" button within the account items was removed. 